### PR TITLE
Problem: Can't provide a reason for timecard edits (#75)

### DIFF
--- a/imports/api/timesheet/methods.js
+++ b/imports/api/timesheet/methods.js
@@ -225,37 +225,43 @@ export const finishWork = new ValidatedMethod({
     }
 })
 
+Timesheet.editWorkSchema = new SimpleSchema({
+	workId: {
+	   	type: String,
+	   	optional: false
+	},
+	newTotal: {
+	  	type: Number,
+	   	optional: false,
+	   	custom: function() {
+	   		if (this.value === 0) {
+	   			return 'New total time can\'t be zero.'
+	   		}
+	    		
+	   		let work = Timesheet.findOne({
+	  			_id: this.field('workId').value
+	  		}) || {}
+
+	   		// let diff = moment.duration((work.totalTime || 0)).seconds() - moment.duration(this.value).seconds() // this one has weird side effects
+	   		let diff = (((work.totalTime || 0) - this.value) < 1000) && (((work.totalTime || 0) - this.value) > -1000)
+
+			if (diff) { // 1 second difference
+				return 'Difference between total times can\'t be zero.'
+			}
+	   	}
+	},
+	reason: {
+	  	type: String,
+	   	optional: true
+	}
+})
+
 export const editWork = new ValidatedMethod({
     name: 'editWork',
-    validate: new SimpleSchema({
-	    workId: {
-	       	type: String,
-	       	optional: false
-	    },
-	    newTotal: {
-	    	type: Number,
-	    	optional: false,
-	    	custom: function() {
-	    		if (this.value === 0) {
-	    			return 'New total time can\'t be zero.'
-	    		}
-	    		
-	    		let work = Timesheet.findOne({
-		  			_id: this.field('workId').value
-		  		}) || {}
-
-	    		// let diff = moment.duration((work.totalTime || 0)).seconds() - moment.duration(this.value).seconds() // this one has weird side effects
-	    		let diff = (((work.totalTime || 0) - this.value) < 1000) && (((work.totalTime || 0) - this.value) > -1000)
-
-				if (diff) { // 1 second difference
-					return 'Difference between total times can\'t be zero.'
-				}
-	    	}
-	    }
-	}).validator({
+    validate: Timesheet.editWorkSchema.validator({
         clean: true
     }),
-    run({ workId, newTotal }) {
+    run({ workId, newTotal, reason }) {
     	if (!Meteor.userId()) {
     		throw new Meteor.Error('Error.', 'You have to be logged in.')
     	}
@@ -286,6 +292,7 @@ export const editWork = new ValidatedMethod({
 					$each: [{
 						oldTime: work.totalTime || 0,
 						newTime: newTotal,
+						reason: reason,
 						editedAt: new Date().getTime(),
 						editedBy: Meteor.userId()
 					}],

--- a/imports/api/timesheet/methods.test.js
+++ b/imports/api/timesheet/methods.test.js
@@ -139,7 +139,8 @@ describe('Timesheet methods', () => {
 
         return callWithPromise('editWork', {
             workId: work._id,
-            newTotal: 600000 // 00:10:00
+            newTotal: 600000, // 00:10:00
+            reason: 'Test reason'
         }).then(tId => {
             let timesheet = Timesheet.findOne({
                 _id: work._id
@@ -147,6 +148,7 @@ describe('Timesheet methods', () => {
 
             assert.ok(timesheet)
             assert.ok(timesheet.history.length > 0)
+            assert.ok(timesheet.history.some(i => i.reason === 'Test reason'))
             assert.ok(timesheet.totalTime >= 600000)
         })
     })

--- a/imports/api/users/methods.js
+++ b/imports/api/users/methods.js
@@ -14,7 +14,6 @@ const approvedUser = userId => {
     let user = Meteor.users.findOne({
        _id: userId
     })
-    console.log(user && user.profile.hourlyRateApproved);
 
     return user && user.profile.hourlyRateApproved
 }

--- a/imports/ui/pages/home/home.ui-test.js
+++ b/imports/ui/pages/home/home.ui-test.js
@@ -83,8 +83,6 @@ describe('Home route', function () {
         assert(browser.isVisible('#js-edit'), true)
 
         browser.click('#js-edit')
-        browser.pause(3000)
-        browser.click('.swal-button--confirm')
         browser.pause(800)
         assert(browser.execute(() => $('.noty_body').text().includes('Difference between total times can\'t be zero.')))
 
@@ -93,8 +91,6 @@ describe('Home route', function () {
         browser.setValue('#js-totalTime', '00:00:00')
         browser.pause(3000)
         browser.click('#js-edit')
-        browser.pause(3000)
-        browser.click('.swal-button--confirm')
         browser.pause(800)
         assert(browser.execute(() => $('.noty_body').text().includes('New total time can\'t be zero.')))
 
@@ -105,13 +101,19 @@ describe('Home route', function () {
 
         browser.click('#js-edit')
         browser.pause(3000)
+        browser.setValue('.swal-content__input', 'Test reason')
+        browser.pause(2000)
         browser.click('.swal-button--confirm')
         browser.pause(3000)
 
         assert(browser.isExisting('.documents-index-item'))
         assert(browser.isVisible('.documents-index-item'))
 
-        assert(browser.execute(() => $($('.documents-index-item').find('td').get(2)).text().includes('+')).value, true)
+        assert(browser.execute(() => {
+            let tds = $('.documents-index-item').find('td')
+
+            return $(tds.get(1)).text().includes('00:10:00') && $(tds.get(2)).text().includes('+') && $(tds.get(3)).text().includes('Test reason')
+        }).value, true)
 
         browser.pause(3000)
 

--- a/imports/ui/pages/timesheet/entry.html
+++ b/imports/ui/pages/timesheet/entry.html
@@ -43,6 +43,7 @@
                         <th>Old total time</th>
                         <th>New total time</th>
                         <th>Change</th>
+                        <th>Reason</th>
                         <th>Edited at</th>
                         <th>Edited by</th>
                       </tr>
@@ -53,6 +54,7 @@
                           <td scope="row">{{formatDuration oldTime}}</td>
                           <td scope="row">{{formatDuration newTime}}</td>
                           <td>{{{change}}}</td>
+                          <td>{{#if reason}}{{reason}}{{else}}-{{/if}}</td>
                           <td>{{formatDate editedAt}}</td>
                           <td>{{editedBy}}</td>
                         </tr>


### PR DESCRIPTION
Solution: Show a modal when editing the timecard that will allow users to optionally enter a reason why they're editing the timecard. Update appropriate server side and client side tests.