### PR TITLE
Problem: User not redirected to login when on settings page (#79)

### DIFF
--- a/imports/startup/client/index.js
+++ b/imports/startup/client/index.js
@@ -1,6 +1,7 @@
 // Import client startup through a single index entry point
 
 import './routes.js'
+import './logout'
 
 import '/imports/ui/shared/error-404/error-404.js'
 import '/imports/ui/shared/footer/footer.js'

--- a/imports/startup/client/logout.js
+++ b/imports/startup/client/logout.js
@@ -1,0 +1,25 @@
+import { Accounts } from 'meteor/accounts-base'
+import { FlowRouter } from 'meteor/kadira:flow-router'
+
+import { notify } from '/imports/modules/notifier.js'
+
+Accounts.onLogout(() => {
+	if (~['entry', 'settings', 'userList', 'payments', 'paymentsView', 'requestPayment'].indexOf(FlowRouter.current().route.name)) { // all protected pages are here
+		FlowRouter.go('/')
+		// $('#signInModal').modal('show') // show the login screen
+	}
+
+	notify('Successfully logged out!', 'success')
+})
+
+const mustBeLoggedIn = (context, redirect, stop) => {
+  	if (!Meteor.userId()) {
+   		FlowRouter.go('/')
+
+   		notify('You have to be logged in to access the page.', 'error')
+  	}
+}
+
+FlowRouter.triggers.enter([mustBeLoggedIn], {
+	except: ['home']
+})

--- a/imports/startup/client/routes.js
+++ b/imports/startup/client/routes.js
@@ -50,7 +50,7 @@ FlowRouter.route('/settings', {
   	}
 })
 FlowRouter.route('/requestpayment', {
-  name: 'settings',
+  name: 'requestPayment',
     action: () => {
       BlazeLayout.render('mainLayout', {
       header: 'header',
@@ -59,7 +59,6 @@ FlowRouter.route('/requestpayment', {
       })
     }
 })
-
 
 modRoutes.route('/users', {
     action: () => {
@@ -91,12 +90,8 @@ modRoutes.route('/payments/:paymentId', {
           sidebar: 'sidebar'
         })
     },
-    name: 'profile'
+    name: 'paymentsView'
 })
-
-
-
-
 
 FlowRouter.notFound = {
   	action: () => {

--- a/imports/ui/pages/user/settings.ui-test.js
+++ b/imports/ui/pages/user/settings.ui-test.js
@@ -87,4 +87,24 @@ describe('Settings route', function () {
 
         assert(browser.execute(count => $('.user-item').length === count - 1, count).value, true)
     })
+
+    it('should redirect user back to home if he/she logs out', () => {
+        browser.url(`${baseUrl}/settings`)
+
+        browser.pause(6000)
+
+        browser.execute(() => Meteor.logout())
+
+        browser.pause(4000)
+
+        assert(browser.execute(() => FlowRouter.current().route.name === 'home').value, true)
+    })
+
+    it('if the user is not logged in, it should show a message and redirect him/her back to home', () => {
+        browser.url(`${baseUrl}/settings`)
+
+        browser.pause(7000)
+        
+        assert(browser.execute(() => FlowRouter.current().route.name === 'home').value, true)
+    })
 })


### PR DESCRIPTION
Solution: Redirect users to home if they're on a protected page and let them know that they have to login in order to access the page. Do the same thing if a user is not logged in and navigates to a protected page. Write appropriate client-side tests.