### PR TITLE
Problem: Approval-pending message shown when user is unauthenticated (#82)

### DIFF
--- a/imports/api/users/methods.js
+++ b/imports/api/users/methods.js
@@ -15,7 +15,7 @@ const approvedUser = userId => {
        _id: userId
     })
 
-    return user && user.profile.hourlyRateApproved
+    return !user || (user && user.profile && user.profile.hourlyRateApproved)
 }
 
 export const saveSettings = new ValidatedMethod({


### PR DESCRIPTION
Solution: Only show the approval pending message if the user is logged in and its hourly rate is not approved, do not show it when user is not logged in.