### PR TITLE
Problem: Add payment details banner is shown even if SWIFT details are correct (#117)

### DIFF
--- a/imports/ui/helpers/global.js
+++ b/imports/ui/helpers/global.js
@@ -52,8 +52,9 @@ Template.registerHelper("math", () => {
 
 // Get the payment details 
 Template.registerHelper("noPaymentDetail", user => {
-  if (user) {
-    return ((user.profile.paypalEmail === undefined || user.profile.paypalEmail === '') && 
-            (user.profile.walletAddress === undefined || user.profile.walletAddress === ''))
+  	if (user) {
+    	return ((user.profile.paypalEmail === undefined || user.profile.paypalEmail === '') && 
+            	(user.profile.walletAddress === undefined || user.profile.walletAddress === '')) &&
+    			(!user.profile.bankDetails)
   } 
 })


### PR DESCRIPTION
Solution: Only show the add payment details banner if payment details are missing.