### PR TITLE
Problem: No summary of costs per project at payment request (#131)

### DIFF
--- a/imports/ui/pages/moderator/payments/paymentsview.html
+++ b/imports/ui/pages/moderator/payments/paymentsview.html
@@ -19,7 +19,7 @@
                   <div class="col-sm-2">
                     <div class="callout callout-danger float-right" style="margin:0">
                       <small class="text-muted">Total pending earnings</small><br>
-                      <strong class="h4">{{#if currentUser.profile.hourlyRateApproved}}<span style="color: red">$ {{fixed totalTimeSheetEarnings }}</span>{{else}}<span style="color: orange">$ {{fixed totalTimeSheetEarnings}}</span>{{/if}}</strong>
+                      <strong class="h4">{{#if currentUser.profile.hourlyRateApproved}}<span class="total-pending" style="color: red">$ {{fixed totalTimeSheetEarnings }}</span>{{else}}<span class="total-pending" style="color: orange">$ {{fixed totalTimeSheetEarnings}}</span>{{/if}}</strong>
                     </div>
                   </div>
                   {{/unless}}
@@ -52,8 +52,29 @@
               </div>
               <br>
               {{#if Template.subscriptionsReady}}
+                {{#if costBreakdown.length}}
+                  <table class="table table-responsive-sm table-hover table-outline mb-0 breakdown">
+                    <thead class="thead-light">
+                      <tr>
+                        <th>Project</th>
+                        <th>Earnings</th>
+                        <th>Percentage</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {{#each costBreakdown}}
+                        <tr class="documents-index-item">
+                          <td scope="row">{{project}}</td>
+                          <td scope="row">{{earnings}}</td>
+                          <td scope="row">{{percentage}}</td>
+                        </tr>
+                      {{/each}}
+                    </tbody>
+                  </table>
+                {{/if}}
+                <br />
                 {{#if timesheets.count}}
-                  <table class="table table-responsive-sm table-hover table-outline mb-0">
+                  <table class="table table-responsive-sm table-hover table-outline mb-0 timesheets">
                     <thead class="thead-light">
                       <tr>
                         <th></th>

--- a/imports/ui/pages/requestpayment/requestpayment.ui-test.js
+++ b/imports/ui/pages/requestpayment/requestpayment.ui-test.js
@@ -55,7 +55,7 @@ describe('Request payment route', function () {
         assert(browser.execute(() => Number($($($('.dashboard').find('.card-body')[2]).find('div')[0]).text().slice(-1))).value > 0, true)
     })
 
-    it('moderator can mark payments as paid', () => {
+    it('moderator can see correct data and mark payments as paid', () => {
         browser.url(`${baseUrl}/moderator/payments`)
         browser.pause(5000)
 
@@ -65,6 +65,17 @@ describe('Request payment route', function () {
             browser.click('.review')
 
             browser.pause(5000)
+
+            // get sum of projects
+            let projectsSum = browser.execute(() => Array.from($('.breakdown').find('tr').map((e, i) => Number($($(i).find('td').get(1)).text().trim().slice(1)))).reduce((i1, i2) => i1 + i2, 0)).value
+            let timesheetsSum = browser.execute(() => Array.from($('.timesheets').find('tr').map((e, i) => Number($($(i).find('td').get(6)).text().trim().slice(1)))).reduce((i1, i2) => i1 + i2, 0)).value
+            let totalPending = browser.execute(() => Number($('.total-pending').text().slice(2))).value
+
+            assert(Math.abs(projectsSum - timesheetsSum) < 1, true)
+            assert(Math.abs(totalPending - timesheetsSum) < 1, true)
+            assert(Math.abs(projectsSum - totalPending) < 1, true)
+
+            browser.pause(2000)
 
             browser.click('.paid')
 


### PR DESCRIPTION
Solution: Show a summary of costs per project on payment request details page, including total earnings per project and a percentage. Update appropriate client side tests.