### PR TITLE
Problem: GitHub API checking for pull requests is slow (#196)

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -32,3 +32,4 @@ github-config-ui@1.0.0
 http@1.4.0
 accounts-password@1.5.0
 service-configuration@1.0.11
+littledata:synced-cron

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -48,6 +48,7 @@ kadira:blaze-layout@2.3.0
 kadira:flow-router@2.12.1
 launch-screen@1.1.1
 less@2.7.12
+littledata:synced-cron@1.5.1
 livedata@1.0.18
 lmieulet:meteor-coverage@1.1.4
 localstorage@1.2.0

--- a/imports/api/repos/methods.js
+++ b/imports/api/repos/methods.js
@@ -4,13 +4,14 @@ import { Promise } from 'meteor/promise'
 import { ValidatedMethod } from 'meteor/mdg:validated-method'
 
 import { Tokens } from '../tokens/tokens'
+import { Repos } from './repos'
 
 const token = (Tokens.findOne({
     _id: 'github-api-token'
 }) || {}).token || ''
 
-export const getGithubRepos = new ValidatedMethod({
-    name: 'getGithubRepos',
+export const updateGithubRepos = new ValidatedMethod({
+    name: 'updateGithubRepos',
     validate: null,
     run({}) {
         let providerUrl = `https://api.github.com/orgs/EmurgoHK/repos${token ? `?access_token=${token}` : ''}`
@@ -51,7 +52,10 @@ export const getGithubRepos = new ValidatedMethod({
                 }
             })
 
-            return repoArray
+            if (repoArray && repoArray.length) {
+                Repos.remove({})
+                repoArray.forEach(i => Repos.insert(i))
+            }
         })
     }
 })

--- a/imports/api/repos/methods.test.js
+++ b/imports/api/repos/methods.test.js
@@ -2,6 +2,7 @@ import { chai, assert } from 'chai'
 import { Meteor } from 'meteor/meteor'
 
 import './methods'
+import { Repos } from './repos'
 
 import { callWithPromise } from '/imports/api/utilities'
 
@@ -13,14 +14,16 @@ describe('Repo methods', function() {
     this.timeout(60000)
     
     it('repos can be fetched from github', () => {
-        return callWithPromise('getGithubRepos', {}).then(data => {
-            assert.ok(data)
+        return callWithPromise('updateGithubRepos', {}).then(data => {
+            let repos = Repos.find({}).fetch()
 
-            if (data.length > 0) {
-                assert.ok(data.length > 0)
-                assert.ok(data[0].repo)
-                assert.ok(data[0].issueCount >= 0)
-                assert.ok(data[0].pullCount >= 0)
+            assert.ok(repos)
+
+            if (repos.length > 0) {
+                assert.ok(repos.length > 0)
+                assert.ok(repos[0].repo)
+                assert.ok(repos[0].issueCount >= 0)
+                assert.ok(repos[0].pullCount >= 0)
             }
         }).catch(err => {})
     })

--- a/imports/api/repos/repos.js
+++ b/imports/api/repos/repos.js
@@ -1,0 +1,3 @@
+import { Mongo } from 'meteor/mongo'
+
+export const Repos = new Mongo.Collection('repos')

--- a/imports/api/repos/server/publications.js
+++ b/imports/api/repos/server/publications.js
@@ -1,0 +1,6 @@
+import { Meteor } from 'meteor/meteor'
+import { Repos } from '../repos'
+
+Meteor.publish('repos', function () {
+	return Repos.find({})
+})

--- a/imports/api/repos/server/startup.js
+++ b/imports/api/repos/server/startup.js
@@ -1,0 +1,11 @@
+import { Mongo } from 'meteor/mongo'
+
+import { updateGithubRepos } from '/imports/api/repos/methods'
+
+Meteor.startup(() => {
+    SyncedCron.add({
+        name: 'Fetch new pull requests',
+        schedule: (parser) => parser.cron('*/5 * * * *'), // every 5 minutes will be sufficient
+        job: () => updateGithubRepos.call({}, (err, data) => {})
+    })
+})

--- a/imports/startup/server/index.js
+++ b/imports/startup/server/index.js
@@ -2,3 +2,4 @@
 
 import './fixtures.js';
 import './register-api.js';
+import './startup'

--- a/imports/startup/server/register-api.js
+++ b/imports/startup/server/register-api.js
@@ -11,3 +11,5 @@ import '/imports/api/payments/methods'
 import '/imports/api/payments/server/publications'
 
 import '/imports/api/repos/methods'
+import '/imports/api/repos/server/publications'
+import '/imports/api/repos/server/startup'

--- a/imports/startup/server/startup.js
+++ b/imports/startup/server/startup.js
@@ -1,0 +1,5 @@
+import { Meteor } from 'meteor/meteor'
+
+Meteor.startup(() => {
+	SyncedCron.start()
+})

--- a/imports/ui/pages/repos/repos.js
+++ b/imports/ui/pages/repos/repos.js
@@ -1,17 +1,16 @@
 import { Template } from 'meteor/templating'
 import { FlowRouter } from 'meteor/kadira:flow-router'
 
-import { getGithubRepos } from '/imports/api/repos/methods.js'
+import { Repos } from '/imports/api/repos/repos'
 
 import './repos.html'
 
-
-Template.repos.onCreated(async function reposCreated() {
+Template.repos.onCreated(function reposCreated() {
     this.activeRepos = new ReactiveVar([])
 
-    getGithubRepos.call({}, async (err, data) => this.activeRepos.set(data))
+    this.autorun(() => this.subscribe('repos'))
 })
 
 Template.repos.helpers({
-    githubRepos: () => Template.instance().activeRepos.get()
+    githubRepos: () => Repos.find({})
 })

--- a/imports/ui/pages/repos/repos.ui-test.js
+++ b/imports/ui/pages/repos/repos.ui-test.js
@@ -25,7 +25,5 @@ describe('Repos route', function () {
     it('it should render correctly', () => {
         assert(browser.isExisting('.card'), true)
         assert(browser.isVisible('.card'), true)
-
-        assert(browser.execute(() => $('.repo-index-item').length >= 0).value, true)
     })
 })


### PR DESCRIPTION
Solution: Set up a cron job every 5 minutes that checks for new pull requests and store results in `Repos` collection.