### PR TITLE
Problem: Freelancers can't view manual payments requests on paid requests (#219)

### DIFF
--- a/imports/ui/pages/requestpayment/manualpayments-list.html
+++ b/imports/ui/pages/requestpayment/manualpayments-list.html
@@ -31,9 +31,11 @@
                                             {{/if}}
                                         </td>
                                         <td>
+                                            {{#if notPaid}}
                                             <button class="js-remove-payment btn btn-sm btn-ghost-danger">
                                                 <strong><i class="fas fa-trash"></i></strong> 
                                             </button>
+                                            {{/if}}
                                         </td>
                                     </tr>
                                 {{/each}}

--- a/imports/ui/pages/requestpayment/manualpayments-list.js
+++ b/imports/ui/pages/requestpayment/manualpayments-list.js
@@ -19,6 +19,9 @@ Template.manualpaymentsList.helpers({
         return ManualPayments.find({ 
             paymentId : Template.instance().paymentId.get()
         }).fetch()
+    },
+    notPaid: function() {
+        return this.status === 'payment-inprogress'
     }
 })
 

--- a/imports/ui/pages/requestpayment/requestpayment.html
+++ b/imports/ui/pages/requestpayment/requestpayment.html
@@ -66,8 +66,8 @@
                                         <td>{{formatDate createAt}}</td>
                                         <td>$ {{fixed amount}}</td>
                                         <td>
+                                            <a href="" data-payment-id="{{_id}}" data-toggle="modal" data-target="#manualPaymentsListModal"><strong>Manual Payments</strong></a>
                                             {{#if notPaid status}}
-                                                <a href="" data-payment-id="{{_id}}" data-toggle="modal" data-target="#manualPaymentsListModal"><strong>Manual Payments</strong></a>
                                                 &nbsp;
                                                 <button data-request-id="{{_id}}" data-toggle="modal" data-target="#manualPaymentModal" class="btn btn-sm btn-ghost-success">
                                                     <strong><i class="fas fa-plus"></i> add </strong> 


### PR DESCRIPTION
Solution: Enable manual payments listings on paid requests and display their status.